### PR TITLE
Fix typo in Insure job posting tools ("Vue, Sass" => "Vue", "Sass")

### DIFF
--- a/data.json
+++ b/data.json
@@ -114,7 +114,7 @@
     "contract": "Full Time",
     "location": "USA Only",
     "languages": ["JavaScript"],
-    "tools": ["Vue, Sass"]
+    "tools": ["Vue", "Sass"]
   },
   {
     "id": 9,


### PR DESCRIPTION
Hey there!

This fixes a small typo in `data.json` where `Vue` and `Sass` were combined as `"Vue, Sass"`.